### PR TITLE
Add version to start page

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1,4 +1,6 @@
 import 'package:flutter/material.dart';
+/// Current application version displayed on the start page.
+const String appVersion = '0.1';
 
 void main() => runApp(const MyApp());
 
@@ -79,6 +81,8 @@ class _MyHomePageState extends State<MyHomePage> {
               '$_counter',
               style: const TextStyle(fontSize: 25),
             ),
+            const SizedBox(height: 20),
+            Text('Version: $appVersion'),
           ],
         ),
       ),


### PR DESCRIPTION
## Summary
- display version number on the home screen

## Testing
- `flutter --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_687e660d4cd483328e6157ddeb459d81